### PR TITLE
Fix Wordle tile IDs to display typed letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
       for (let r=0; r<ROWS; r++) {
         const rowEl = document.createElement('div'); rowEl.className = 'row';
         for (let c=0; c<COLS; c++) {
-          const t = document.createElement('div'); t.className = 'tile'; t.id = `t-{r}-{c}`;
+          const t = document.createElement('div'); t.className = 'tile'; t.id = `t-${r}-${c}`;
           rowEl.appendChild(t);
         }
         board.appendChild(rowEl);


### PR DESCRIPTION
## Summary
- correct board tile id interpolation so draw() finds elements

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689f92c2af308331a229f5d675ff1b4b