### PR TITLE
Add reload caching for index.html

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,16 @@ self.addEventListener('message', e => {
 });
 
 self.addEventListener('install', (e) => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+  e.waitUntil((async () => {
+    const c = await caches.open(CACHE);
+    for (const url of ASSETS) {
+      if (url.endsWith('index.html')) {
+        await c.add(new Request(url, {cache: 'reload'}));
+      } else {
+        await c.add(url);
+      }
+    }
+  })());
 });
 
 self.addEventListener('activate', (e) => {


### PR DESCRIPTION
## Summary
- Cache each asset individually in service worker install step
- Bypass HTTP cache for index.html using `Request` with `cache: 'reload'`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe00b3848331b6278b41eefb1b0a