### PR TITLE
Ensure service worker reloads HTML from network

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@ self.addEventListener('fetch', (e) => {
   // Network-first for html, cache-first for others
   if (url.pathname.endsWith('.html') || url.pathname === '/' ) {
     e.respondWith((async () => {
-      try { return await fetch(e.request); }
+      try { return await fetch(e.request, {cache: 'reload'}); }
       catch { return caches.match('./index.html'); }
     })());
   } else {


### PR DESCRIPTION
## Summary
- Force HTML requests to bypass HTTP cache by using `fetch(e.request, {cache: 'reload'})` in the service worker

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fbf3b4534833192427e3ba7d0a933